### PR TITLE
Reduce amount of aliasing

### DIFF
--- a/tau/osu.Game.Rulesets.tau/Objects/Drawables/DrawabletauHitObject.cs
+++ b/tau/osu.Game.Rulesets.tau/Objects/Drawables/DrawabletauHitObject.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
 
             AddInternal(Box = new Box
             {
+                EdgeSmoothness = new Vector2(1f),
                 RelativeSizeAxes = Axes.Both,
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,

--- a/tau/osu.Game.Rulesets.tau/UI/Cursor/tauCursor.cs
+++ b/tau/osu.Game.Rulesets.tau/UI/Cursor/tauCursor.cs
@@ -8,10 +8,12 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Graphics.Shaders;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Tau.Objects.Drawables;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Tau.UI.Cursor
 {
@@ -92,12 +94,19 @@ namespace osu.Game.Rulesets.Tau.UI.Cursor
 
             private class AbsoluteCursor : CursorContainer
             {
-                protected override Drawable CreateCursor() => new CircularProgress
+                protected override Drawable CreateCursor() => new CircularContainer
                 {
                     Size = new Vector2(15),
                     Origin = Anchor.Centre,
-                    InnerRadius = 0.25f,
-                    Current = new Bindable<double>(1)
+                    Masking = true,
+                    BorderColour = Color4.White,
+                    BorderThickness = 4,
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        AlwaysPresent = true,
+                        Alpha = 0,
+                    }
                 };
             }
 
@@ -135,6 +144,7 @@ namespace osu.Game.Rulesets.Tau.UI.Cursor
                                 },
                                 new Box
                                 {
+                                    EdgeSmoothness = new Vector2(1f),
                                     Anchor = Anchor.TopCentre,
                                     Origin = Anchor.TopCentre,
                                     RelativeSizeAxes = Axes.Y,

--- a/tau/osu.Game.Rulesets.tau/UI/Cursor/tauCursor.cs
+++ b/tau/osu.Game.Rulesets.tau/UI/Cursor/tauCursor.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Graphics.Shaders;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Tau.Objects.Drawables;

--- a/tau/osu.Game.Rulesets.tau/UI/tauPlayfield.cs
+++ b/tau/osu.Game.Rulesets.tau/UI/tauPlayfield.cs
@@ -14,6 +14,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
+using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Tau.Configuration;
 using osu.Game.Rulesets.Tau.Objects.Drawables;
 using osu.Game.Rulesets.Tau.UI.Cursor;
@@ -54,16 +55,23 @@ namespace osu.Game.Rulesets.Tau.UI
                     Origin = Anchor.Centre,
                     Children = new Drawable[]
                     {
-                        new CircularProgress
+                        new CircularContainer
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Current = new BindableDouble(1),
-                            InnerRadius = 0.025f / 4,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
+                            Masking = true,
                             FillMode = FillMode.Fit,
                             FillAspectRatio = 1, // 1:1 Aspect ratio to get a perfect circle
-                        }
+                            BorderThickness = 3,
+                            BorderColour = Color4.White,
+                            Child = new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                AlwaysPresent = true,
+                                Alpha = 0,
+                            }
+                        },
                     }
                 },
                 HitObjectContainer,

--- a/tau/osu.Game.Rulesets.tau/UI/tauPlayfield.cs
+++ b/tau/osu.Game.Rulesets.tau/UI/tauPlayfield.cs
@@ -8,7 +8,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.UserInterface;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;


### PR DESCRIPTION
Changes include:
* Replacing CircularProgress with CircularContainers (Ring, Cursor) 
* Adding EdgeSmoothness to Boxes (Paddle line, HitNotes)

The paddle seems to be a bit complicated to smooth out, I was thinking of using a long rotating square to mask a CircularContainer, but that may be overstepping my boundaries since that will change how things look. A shader might also do the job, but that seems to be out of my league. (Or maybe there's an obviously simple way to do it and I'm just too dim)

Performance impact is minimal from my testing.

Oh and it's a pleasure to meet ya! I'm [Bloom](https://osu.ppy.sh/users/6443205) in osu! so hit me up if you're cool with that sort of thing.