### PR TITLE
Fix missing hitsounding for notes converted from sliders

### DIFF
--- a/osu.Game.Rulesets.tau/Beatmaps/tauBeatmapConverter.cs
+++ b/osu.Game.Rulesets.tau/Beatmaps/tauBeatmapConverter.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Tau.Beatmaps
                 default:
                     return new TauHitObject
                     {
-                        Samples = original.Samples,
+                        Samples = original is IHasCurve ? ((IHasCurve)original).NodeSamples[0] : original.Samples,
                         StartTime = original.StartTime,
                         PositionToEnd = position,
                         NewCombo = comboData?.NewCombo ?? false,


### PR DESCRIPTION
Notes converted from sliders were missing their correct hitsounding.
It is very noticeable at the beginning of this map
https://osu.ppy.sh/beatmapsets/1054045#osu/2202493