### PR TITLE
Fix object placement being in incorrect corner

### DIFF
--- a/osu.Game.Rulesets.tau/Extensions.cs
+++ b/osu.Game.Rulesets.tau/Extensions.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Tau
         public static float GetHitObjectAngle(this Vector2 target)
         {
             Vector2 offset = new Vector2(256, 192) - target; // Using centre of playfield.
-            return (float)MathHelper.RadiansToDegrees(Math.Atan2(offset.X, offset.Y));
+            return (float)MathHelper.RadiansToDegrees(Math.Atan2(offset.X, -offset.Y)) - 90;
         }
     }
 }

--- a/osu.Game.Rulesets.tau/Extensions.cs
+++ b/osu.Game.Rulesets.tau/Extensions.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Tau
         public static float GetHitObjectAngle(this Vector2 target)
         {
             Vector2 offset = new Vector2(256, 192) - target; // Using centre of playfield.
-            return (float)MathHelper.RadiansToDegrees(Math.Atan2(-offset.X, -offset.Y));
+            return (float)MathHelper.RadiansToDegrees(Math.Atan2(offset.X, offset.Y));
         }
     }
 }


### PR DESCRIPTION
Forgot to do this, now it places standard objects relative to the actuall position from the centre.