### PR TITLE
Only store angle within hit objects

### DIFF
--- a/osu.Game.Rulesets.Tau/Configuration/TauRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Tau/Configuration/TauRulesetConfigManager.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Tau.Configuration
 
             Set(TauRulesetSettings.ShowVisualizer, true);
             Set(TauRulesetSettings.PlayfieldDim, 0.3f, 0, 1, 0.01f);
-            Set(TauRulesetSettings.BeatSize, 10f, 5, 25, 1f);
+            Set(TauRulesetSettings.BeatSize, 16f, 10, 25, 1f);
         }
     }
 

--- a/osu.Game.Rulesets.Tau/Extensions.cs
+++ b/osu.Game.Rulesets.Tau/Extensions.cs
@@ -9,6 +9,11 @@ namespace osu.Game.Rulesets.Tau
 {
     public static class Extensions
     {
+        public static Vector2 GetCircularPosition(float distance, float angle)
+        {
+            return new Vector2(-(distance * (float)Math.Cos((angle + 90f) * (float)(Math.PI / 180))), -(distance * (float)Math.Sin((angle + 90f) * (float)(Math.PI / 180))));
+        }
+
         public static float GetDegreesFromPosition(this Vector2 target, Vector2 self)
         {
             Vector2 offset = self - target;
@@ -18,7 +23,7 @@ namespace osu.Game.Rulesets.Tau
         public static float GetHitObjectAngle(this Vector2 target)
         {
             Vector2 offset = new Vector2(256, 192) - target; // Using centre of playfield.
-            return (float)MathHelper.RadiansToDegrees(Math.Atan2(offset.X, -offset.Y)) - 90;
+            return (float)MathHelper.RadiansToDegrees(Math.Atan2(offset.X, -offset.Y)) - 180;
         }
     }
 }

--- a/osu.Game.Rulesets.Tau/Extensions.cs
+++ b/osu.Game.Rulesets.Tau/Extensions.cs
@@ -10,9 +10,7 @@ namespace osu.Game.Rulesets.Tau
     public static class Extensions
     {
         public static Vector2 GetCircularPosition(float distance, float angle)
-        {
-            return new Vector2(-(distance * (float)Math.Cos((angle + 90f) * (float)(Math.PI / 180))), -(distance * (float)Math.Sin((angle + 90f) * (float)(Math.PI / 180))));
-        }
+            => new Vector2(-(distance * (float)Math.Cos((angle + 90f) * (float)(Math.PI / 180))), -(distance * (float)Math.Sin((angle + 90f) * (float)(Math.PI / 180))));
 
         public static float GetDegreesFromPosition(this Vector2 target, Vector2 self)
         {

--- a/osu.Game.Rulesets.Tau/Mods/TauModHardRock.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModHardRock.cs
@@ -5,6 +5,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Tau.Objects;
 using osuTK;
+using System;
 
 namespace osu.Game.Rulesets.Tau.Mods
 {
@@ -16,8 +17,16 @@ namespace osu.Game.Rulesets.Tau.Mods
         public void ApplyToHitObject(HitObject hitObject)
         {
             var tauObject = (TauHitObject)hitObject;
+            while (tauObject.Angle < 0) tauObject.Angle += 360;
+            tauObject.Angle %= 360;
 
-            tauObject.PositionToEnd = new Vector2(tauObject.PositionToEnd.X, -tauObject.PositionToEnd.Y);
+            var newAngle = 0.0f;
+            if (tauObject.Angle >= 0 && tauObject.Angle < 180)
+                newAngle = 90 + (90 - tauObject.Angle);
+            else if (tauObject.Angle >= 180)
+                newAngle = 270 + (270 - tauObject.Angle);
+
+            tauObject.Angle = newAngle;
         }
     }
 }

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                                 RelativeSizeAxes= Axes.Both
                             },
                             IntersectArea = new Container{
-                                Size = new Vector2(10),
+                                Size = new Vector2(16),
                                 RelativeSizeAxes = Axes.None,
                                 Origin = Anchor.Centre,
                                 Anchor = Anchor.Centre,
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             Position = Vector2.Zero;
         }
 
-        private readonly Bindable<float> size = new Bindable<float>(10); // Change as you see fit.
+        private readonly Bindable<float> size = new Bindable<float>(16); // Change as you see fit.
 
         [BackgroundDependencyLoader(true)]
         private void load(TauRulesetConfigManager config)

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
 
             Box.FadeIn(HitObject.TimeFadeIn);
             //Box.MoveToY(-.5f, HitObject.TimePreempt);
-            Box.MoveTo(new Vector2(-(0.5f * (float)Math.Cos(a)), -(.5f * (float)Math.Sin(a))), HitObject.TimePreempt);
+            Box.MoveTo(new Vector2(-(0.485f * (float)Math.Cos(a)), -(.485f * (float)Math.Sin(a))), HitObject.TimePreempt);
 
         }
 

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                 }
             );
 
-            Box.Rotation = hitObject.Angle;
+            Rotation = hitObject.Angle;
             Position = Vector2.Zero;
         }
 
@@ -95,7 +95,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             var a = b *= (float)(Math.PI / 180);
 
             Box.FadeIn(HitObject.TimeFadeIn);
-            Box.MoveTo(new Vector2(-(0.485f * (float)Math.Cos(a)), -(.485f * (float)Math.Sin(a))), HitObject.TimePreempt);
+            Box.MoveToY(-0.485f, HitObject.TimePreempt);
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
@@ -146,7 +146,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
 
                     Box.ScaleTo(2f, time_fade_hit, Easing.OutCubic)
                        .FadeColour(Color4.Yellow, time_fade_hit, Easing.OutCubic)
-                       .MoveToOffset(new Vector2(-(.1f * (float)Math.Cos(a)), -(.1f * (float)Math.Sin(a))), time_fade_hit, Easing.OutCubic)
+                       .MoveToOffset(new Vector2(0, -.1f), time_fade_hit, Easing.OutCubic)
                        .FadeOut(time_fade_hit);
 
                     this.FadeOut(time_fade_hit);
@@ -159,7 +159,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
 
                     Box.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
                        .FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint)
-                       .MoveToOffset(new Vector2(-(.1f * (float)Math.Cos(d)), -(.1f * (float)Math.Sin(d))), time_fade_hit, Easing.OutCubic)
+                       .MoveToOffset(new Vector2(0, -.1f), time_fade_hit, Easing.OutCubic)
                        .FadeOut(time_fade_miss);
 
                     this.FadeOut(time_fade_miss);

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
@@ -48,17 +48,18 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-            RelativePositionAxes = Axes.Both;
-
+            RelativeSizeAxes = Axes.Both;
+            Size = Vector2.One;
             AddRangeInternal(new Drawable[]
                 {
                     Box = new Box
                     {
                         EdgeSmoothness = new Vector2(1f),
-                        RelativeSizeAxes = Axes.Both,
+                        //RelativeSizeAxes = Axes.Both,
+                        RelativePositionAxes = Axes.Both,
                         Origin = Anchor.Centre,
                         Anchor = Anchor.Centre,
-                        Alpha = 0.05f
+                        Alpha = 0.05f,
                     },
                     IntersectArea = new Box
                     {
@@ -73,7 +74,6 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             );
 
             Box.Rotation = hitObject.Angle;
-
             Position = Vector2.Zero;
         }
 
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
         private void load(TauRulesetConfigManager config)
         {
             config?.BindWith(TauRulesetSettings.BeatSize, size);
-            size.BindValueChanged(value => this.Size = new Vector2(value.NewValue), true);
+            size.BindValueChanged(value => Box.Size = new Vector2(value.NewValue), true);
         }
 
         protected override void UpdateInitialTransforms()
@@ -93,7 +93,9 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             var a = b *= (float)(Math.PI / 180);
 
             Box.FadeIn(HitObject.TimeFadeIn);
-            this.MoveTo(new Vector2(-(TauPlayfield.UNIVERSAL_SCALE * 0.8f * (float)Math.Cos(a)), -(TauPlayfield.UNIVERSAL_SCALE * 0.8f * (float)Math.Sin(a))), HitObject.TimePreempt);
+            //Box.MoveToY(-.5f, HitObject.TimePreempt);
+            Box.MoveTo(new Vector2(-(0.5f * (float)Math.Cos(a)), -(.5f * (float)Math.Sin(a))), HitObject.TimePreempt);
+
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
@@ -142,10 +144,10 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                     var b = HitObject.Angle;
                     var a = b *= (float)(Math.PI / 180);
 
-                    Box.ScaleTo(2f, time_fade_hit, Easing.OutCubic)
+                    /* Box.ScaleTo(2f, time_fade_hit, Easing.OutCubic)
                        .FadeColour(Color4.Yellow, time_fade_hit, Easing.OutCubic)
                        .MoveToOffset(new Vector2(-(50 * (float)Math.Cos(a)), -(50 * (float)Math.Sin(a))), time_fade_hit, Easing.OutCubic)
-                       .FadeOut(time_fade_hit);
+                       .FadeOut(time_fade_hit); */
 
                     this.FadeOut(time_fade_hit);
 
@@ -155,10 +157,10 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                     var c = HitObject.Angle;
                     var d = c *= (float)(Math.PI / 180);
 
-                    Box.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
+                    /* Box.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
                        .FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint)
                        .MoveToOffset(new Vector2(-(50 * (float)Math.Cos(d)), -(50 * (float)Math.Sin(d))), time_fade_hit, Easing.OutCubic)
-                       .FadeOut(time_fade_miss);
+                       .FadeOut(time_fade_miss); */
 
                     this.FadeOut(time_fade_miss);
 

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
@@ -20,8 +21,8 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
 {
     public class DrawableTauHitObject : DrawableHitObject<TauHitObject>, IKeyBindingHandler<TauAction>
     {
-        public Box Box;
-        public Box IntersectArea;
+        public Container Box;
+        public Container IntersectArea;
 
         public Func<DrawableTauHitObject, bool> CheckValidation;
 
@@ -52,24 +53,25 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             Size = Vector2.One;
             AddRangeInternal(new Drawable[]
                 {
-                    Box = new Box
+                    Box = new Container
                     {
-                        EdgeSmoothness = new Vector2(1f),
-                        //RelativeSizeAxes = Axes.Both,
                         RelativePositionAxes = Axes.Both,
                         Origin = Anchor.Centre,
                         Anchor = Anchor.Centre,
                         Alpha = 0.05f,
+                        Children = new Drawable[]{
+                            new Box{
+                                RelativeSizeAxes= Axes.Both
+                            },
+                            IntersectArea = new Container{
+                                Size = new Vector2(10),
+                                RelativeSizeAxes = Axes.None,
+                                Origin = Anchor.Centre,
+                                Anchor = Anchor.Centre,
+                                AlwaysPresent = true
+                            }
+                        }
                     },
-                    IntersectArea = new Box
-                    {
-                        Size = new Vector2(10),
-                        RelativeSizeAxes = Axes.None,
-                        Origin = Anchor.Centre,
-                        Anchor = Anchor.Centre,
-                        Alpha = 0,
-                        AlwaysPresent = true
-                    }
                 }
             );
 

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
@@ -95,9 +95,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             var a = b *= (float)(Math.PI / 180);
 
             Box.FadeIn(HitObject.TimeFadeIn);
-            //Box.MoveToY(-.5f, HitObject.TimePreempt);
             Box.MoveTo(new Vector2(-(0.485f * (float)Math.Cos(a)), -(.485f * (float)Math.Sin(a))), HitObject.TimePreempt);
-
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
@@ -146,10 +144,10 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                     var b = HitObject.Angle;
                     var a = b *= (float)(Math.PI / 180);
 
-                    /* Box.ScaleTo(2f, time_fade_hit, Easing.OutCubic)
+                    Box.ScaleTo(2f, time_fade_hit, Easing.OutCubic)
                        .FadeColour(Color4.Yellow, time_fade_hit, Easing.OutCubic)
-                       .MoveToOffset(new Vector2(-(50 * (float)Math.Cos(a)), -(50 * (float)Math.Sin(a))), time_fade_hit, Easing.OutCubic)
-                       .FadeOut(time_fade_hit); */
+                       .MoveToOffset(new Vector2(-(.1f * (float)Math.Cos(a)), -(.1f * (float)Math.Sin(a))), time_fade_hit, Easing.OutCubic)
+                       .FadeOut(time_fade_hit);
 
                     this.FadeOut(time_fade_hit);
 
@@ -159,10 +157,10 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                     var c = HitObject.Angle;
                     var d = c *= (float)(Math.PI / 180);
 
-                    /* Box.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
+                    Box.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
                        .FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint)
-                       .MoveToOffset(new Vector2(-(50 * (float)Math.Cos(d)), -(50 * (float)Math.Sin(d))), time_fade_hit, Easing.OutCubic)
-                       .FadeOut(time_fade_miss); */
+                       .MoveToOffset(new Vector2(-(.1f * (float)Math.Cos(d)), -(.1f * (float)Math.Sin(d))), time_fade_hit, Easing.OutCubic)
+                       .FadeOut(time_fade_miss);
 
                     this.FadeOut(time_fade_miss);
 

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauJudgement.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauJudgement.cs
@@ -21,6 +21,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
         public DrawableTauJudgement(JudgementResult result, DrawableTauHitObject judgedObject)
             : base(result, judgedObject)
         {
+            RelativePositionAxes = Axes.Both;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauJudgement.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauJudgement.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             : base(result, judgedObject)
         {
             RelativePositionAxes = Axes.Both;
+            Scale = new Vector2(1.66f);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Tau/Objects/TauHitObject.cs
+++ b/osu.Game.Rulesets.Tau/Objects/TauHitObject.cs
@@ -22,7 +22,6 @@ namespace osu.Game.Rulesets.Tau.Objects
         public double TimeFadeIn = 400;
 
         public float Angle { get; set; }
-        public Vector2 PositionToEnd { get; set; }
 
         public virtual bool NewCombo { get; set; }
 
@@ -64,7 +63,7 @@ namespace osu.Game.Rulesets.Tau.Objects
         {
             base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
 
-            TimePreempt = (float) BeatmapDifficulty.DifficultyRange(difficulty.ApproachRate, 1800, 1200, 450);
+            TimePreempt = (float)BeatmapDifficulty.DifficultyRange(difficulty.ApproachRate, 1800, 1200, 450);
             TimeFadeIn = 100;
         }
     }

--- a/osu.Game.Rulesets.Tau/Replays/TauAutoGenerator.cs
+++ b/osu.Game.Rulesets.Tau/Replays/TauAutoGenerator.cs
@@ -53,14 +53,14 @@ namespace osu.Game.Rulesets.Tau.Replays
                 {
                     float b = Beatmap.HitObjects[i - 1].Angle * MathF.PI / 180;
 
-                    Replay.Frames.Add(new TauReplayFrame(h.StartTime - reactionTime, new Vector2(offset - (cursorDistance * MathF.Cos(b)), offset - (cursorDistance * MathF.Sin(b)))));
+                    Replay.Frames.Add(new TauReplayFrame(h.StartTime - reactionTime, Extensions.GetCircularPosition(cursorDistance, h.Angle) + new Vector2(offset)));
 
                     buttonIndex = (int)TauAction.LeftButton;
                 }
 
                 float a = h.Angle * MathF.PI / 180;
 
-                Replay.Frames.Add(new TauReplayFrame(h.StartTime, new Vector2(offset - (cursorDistance * MathF.Cos(a)), offset - (cursorDistance * MathF.Sin(a))), (TauAction)(buttonIndex++ % 2)));
+                Replay.Frames.Add(new TauReplayFrame(h.StartTime, Extensions.GetCircularPosition(cursorDistance, h.Angle) + new Vector2(offset), (TauAction)(buttonIndex++ % 2)));
             }
 
             return Replay;

--- a/osu.Game.Rulesets.Tau/Replays/TauAutoGenerator.cs
+++ b/osu.Game.Rulesets.Tau/Replays/TauAutoGenerator.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Tau.Replays
         /// </summary>
         private int buttonIndex;
 
-        private const float offset = (768 / 2f) * TauPlayfield.UNIVERSAL_SCALE;
+        private const float offset = 768 / 2f;
         private const float cursorDistance = 250;
 
         public override Replay Generate()

--- a/osu.Game.Rulesets.Tau/Replays/TauAutoGenerator.cs
+++ b/osu.Game.Rulesets.Tau/Replays/TauAutoGenerator.cs
@@ -51,15 +51,12 @@ namespace osu.Game.Rulesets.Tau.Replays
                 //Make the cursor stay at the last note's position if there's enough time between the notes
                 if (i > 0 && h.StartTime - Beatmap.HitObjects[i - 1].StartTime > reactionTime)
                 {
-                    float b = Beatmap.HitObjects[i - 1].Angle * MathF.PI / 180;
+                    float prevAngle = Beatmap.HitObjects[i - 1].Angle;
 
-                    Replay.Frames.Add(new TauReplayFrame(h.StartTime - reactionTime, Extensions.GetCircularPosition(cursorDistance, h.Angle) + new Vector2(offset)));
+                    Replay.Frames.Add(new TauReplayFrame(h.StartTime - reactionTime, Extensions.GetCircularPosition(cursorDistance, prevAngle) + new Vector2(offset)));
 
                     buttonIndex = (int)TauAction.LeftButton;
                 }
-
-                float a = h.Angle * MathF.PI / 180;
-
                 Replay.Frames.Add(new TauReplayFrame(h.StartTime, Extensions.GetCircularPosition(cursorDistance, h.Angle) + new Vector2(offset), (TauAction)(buttonIndex++ % 2)));
             }
 

--- a/osu.Game.Rulesets.Tau/UI/Cursor/TauCursor.cs
+++ b/osu.Game.Rulesets.Tau/UI/Cursor/TauCursor.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Tau.UI.Cursor
                         HitReceptor = new Box
                         {
                             Height = 50,
-                            Width = (float)convertValue(cs),
+                            Width = (float)convertValue(cs)*1.6f,
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
                             Alpha = 0,

--- a/osu.Game.Rulesets.Tau/UI/Cursor/TauCursor.cs
+++ b/osu.Game.Rulesets.Tau/UI/Cursor/TauCursor.cs
@@ -63,7 +63,6 @@ namespace osu.Game.Rulesets.Tau.UI.Cursor
                     Origin = Anchor.Centre,
                     FillMode = FillMode.Fit,
                     FillAspectRatio = 1, // 1:1 Aspect Ratio.
-                    Size = new Vector2(0.6f),
                     Children = new Drawable[]
                     {
                         HitReceptor = new Box
@@ -134,7 +133,6 @@ namespace osu.Game.Rulesets.Tau.UI.Cursor
                             Masking = true,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            Size = new Vector2(0.6f),
                             Children = new Drawable[]
                             {
                                 new CircularProgress

--- a/osu.Game.Rulesets.Tau/UI/KiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Tau/UI/KiaiHitExplosion.cs
@@ -21,8 +21,9 @@ namespace osu.Game.Rulesets.Tau.UI
 
         public KiaiHitExplosion(DrawableHitObject judgedObject, bool isSmall = false)
         {
-            Height = 10;
-            Width = 10;
+            Height = 16;
+            Width = 16;
+            RelativePositionAxes = Axes.Both;
 
             // scale roughly in-line with visual appearance of notes
             Scale = new Vector2(1f, 0.5f);

--- a/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
@@ -156,7 +156,7 @@ namespace osu.Game.Rulesets.Tau.UI
             if (judgedObject.HitObject.Kiai && result.Type != HitResult.Miss)
                 kiaiExplosionContainer.Add(new KiaiHitExplosion(judgedObject)
                 {
-                    Position = new Vector2(-(215 * (float)Math.Cos(a)), -(215 * (float)Math.Sin(a))),
+                    Position = new Vector2(-(.475f * (float)Math.Cos(a)), -(.475f * (float)Math.Sin(a))),
                     Rotation = tauObj.Box.Rotation,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre

--- a/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
@@ -40,8 +40,11 @@ namespace osu.Game.Rulesets.Tau.UI
 
         public TauPlayfield(BeatmapDifficulty difficulty)
         {
+            RelativeSizeAxes = Axes.None;
             cursor = new TauCursor(difficulty);
-
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            Size = new Vector2(768);
             AddRangeInternal(new Drawable[]
             {
                 judgementLayer = new JudgementContainer<DrawableTauJudgement>
@@ -56,16 +59,14 @@ namespace osu.Game.Rulesets.Tau.UI
                 {
                     Colour = Color4.Black,
                     RelativeSizeAxes = Axes.Both,
-                    Size = new Vector2(UNIVERSAL_SCALE),
-                    FillAspectRatio = 1,
-                    FillMode = FillMode.Fit,
+                    /* FillAspectRatio = 1,
+                    FillMode = FillMode.Fit, */
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Size = new Vector2(UNIVERSAL_SCALE),
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Children = new Drawable[]
@@ -76,8 +77,8 @@ namespace osu.Game.Rulesets.Tau.UI
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Masking = true,
-                            FillMode = FillMode.Fit,
-                            FillAspectRatio = 1, // 1:1 Aspect ratio to get a perfect circle
+                            /* FillMode = FillMode.Fit,
+                            FillAspectRatio = 1, // 1:1 Aspect ratio to get a perfect circle */
                             BorderThickness = 3,
                             BorderColour = Color4.White,
                             Child = new Box
@@ -89,19 +90,7 @@ namespace osu.Game.Rulesets.Tau.UI
                         },
                     }
                 },
-                new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    FillMode = FillMode.Fit,
-                    FillAspectRatio = 1,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Size = new Vector2(UNIVERSAL_SCALE),
-                    Children = new Drawable[]
-                    {
-                        HitObjectContainer,
-                    }
-                },
+                HitObjectContainer,
                 cursor,
                 kiaiExplosionContainer = new Container<KiaiHitExplosion>
                 {
@@ -160,7 +149,7 @@ namespace osu.Game.Rulesets.Tau.UI
             {
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,
-                Position = new Vector2(-(285 * (float)Math.Cos(a)), -(285 * (float)Math.Sin(a))),
+                Position = new Vector2(-(.55f * (float)Math.Cos(a)), -(.55f * (float)Math.Sin(a))),
                 Rotation = tauObj.Box.Rotation + 90,
             };
 
@@ -187,7 +176,6 @@ namespace osu.Game.Rulesets.Tau.UI
             private void load(TauRulesetConfigManager settings)
             {
                 RelativeSizeAxes = Axes.Both;
-                Size = new Vector2(UNIVERSAL_SCALE);
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;
 

--- a/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Rulesets.Tau.UI
             {
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,
-                Position = new Vector2(-(.55f * (float)Math.Cos(a)), -(.55f * (float)Math.Sin(a))),
+                Position = new Vector2(-(.6f * (float)Math.Cos(a)), -(.6f * (float)Math.Sin(a))),
                 Rotation = tauObj.Box.Rotation + 90,
             };
 

--- a/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
@@ -75,8 +75,6 @@ namespace osu.Game.Rulesets.Tau.UI
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Masking = true,
-                            /* FillMode = FillMode.Fit,
-                            FillAspectRatio = 1, // 1:1 Aspect ratio to get a perfect circle */
                             BorderThickness = 3,
                             BorderColour = Color4.White,
                             Child = new Box

--- a/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
@@ -139,14 +139,12 @@ namespace osu.Game.Rulesets.Tau.UI
 
             var tauObj = (DrawableTauHitObject)judgedObject;
 
-            var a = tauObj.HitObject.Angle * (float)(Math.PI / 180);
-
             DrawableTauJudgement explosion = new DrawableTauJudgement(result, tauObj)
             {
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,
-                Position = new Vector2(-(.6f * (float)Math.Cos(a)), -(.6f * (float)Math.Sin(a))),
-                Rotation = tauObj.Box.Rotation + 90,
+                Position = Extensions.GetCircularPosition(.6f, tauObj.HitObject.Angle),
+                Rotation = tauObj.HitObject.Angle,
             };
 
             judgementLayer.Add(explosion);
@@ -154,8 +152,8 @@ namespace osu.Game.Rulesets.Tau.UI
             if (judgedObject.HitObject.Kiai && result.Type != HitResult.Miss)
                 kiaiExplosionContainer.Add(new KiaiHitExplosion(judgedObject)
                 {
-                    Position = new Vector2(-(.475f * (float)Math.Cos(a)), -(.475f * (float)Math.Sin(a))),
-                    Rotation = tauObj.Box.Rotation,
+                    Position = Extensions.GetCircularPosition(.475f, tauObj.HitObject.Angle),
+                    Rotation = tauObj.HitObject.Angle,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre
                 });

--- a/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
@@ -59,8 +59,6 @@ namespace osu.Game.Rulesets.Tau.UI
                 {
                     Colour = Color4.Black,
                     RelativeSizeAxes = Axes.Both,
-                    /* FillAspectRatio = 1,
-                    FillMode = FillMode.Fit, */
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },

--- a/osu.Game.Rulesets.Tau/UI/TauPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauPlayfieldAdjustmentContainer.cs
@@ -10,15 +10,13 @@ namespace osu.Game.Rulesets.Tau.UI
         protected override Container<Drawable> Content => content;
         private readonly Container content;
 
-        private const float playfield_size_adjust = 1f;
-
         public TauPlayfieldAdjustmentContainer()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
             // Calculated from osu!stable as 512 (default gamefield size) / 640 (default window size)
-            Size = new Vector2(playfield_size_adjust);
+            Size = new Vector2(.6f);
 
             InternalChild = new Container
             {


### PR DESCRIPTION
- [x] Depends on #102 

Removes EndPosition in favor of rotating the entire hitobject, which will generate the same result and is easier to process mentally.

Also added the following extension, which replaces existing cases of generating a position from an angle.
```cs
public static Vector2 GetCircularPosition(float distance, float angle)
{
    return new Vector2(-(distance * (float)Math.Cos((angle + 90f) * (float)(Math.PI / 180))), -(distance * (float)Math.Sin((angle + 90f) * (float)(Math.PI / 180))));
}
```
