### PR TITLE
Implement "feign" modifier to regular beats

### DIFF
--- a/osu.Game.Rulesets.Tau/Beatmaps/TauBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Tau/Beatmaps/TauBeatmapConverter.cs
@@ -8,6 +8,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Tau.Objects;
+using osu.Game.Audio;
 using osuTK;
 
 namespace osu.Game.Rulesets.Tau.Beatmaps
@@ -27,6 +28,7 @@ namespace osu.Game.Rulesets.Tau.Beatmaps
         {
             Vector2 position = ((IHasPosition)original).Position;
             var comboData = original as IHasCombo;
+            bool isFeign = (original is IHasPathWithRepeats tmp ? tmp.NodeSamples[0] : original.Samples).Any(s => s.Name == HitSampleInfo.HIT_WHISTLE);
 
             switch (original)
             {
@@ -34,6 +36,7 @@ namespace osu.Game.Rulesets.Tau.Beatmaps
                     return new Beat
                     {
                         Samples = original is IHasPathWithRepeats curve ? curve.NodeSamples[0] : original.Samples,
+                        Feign = isFeign,
                         StartTime = original.StartTime,
                         Angle = position.GetHitObjectAngle(),
                         NewCombo = comboData?.NewCombo ?? false,

--- a/osu.Game.Rulesets.Tau/Objects/Beat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Beat.cs
@@ -2,5 +2,6 @@ namespace osu.Game.Rulesets.Tau.Objects
 {
     public class Beat : TauHitObject
     {
+        public bool Feign { get; set; } = false;
     }
 }

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
@@ -55,8 +55,9 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                     },
                 }
             );
+            Colour = hitObject.Feign ? Color4.Aqua : Color4.White;
 
-            Rotation = hitObject.Angle;
+            Rotation = hitObject.Angle + (hitObject.Feign ? 180 : 0);
             Position = Vector2.Zero;
         }
 
@@ -75,6 +76,9 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
 
             Box.FadeIn(HitObject.TimeFadeIn);
             Box.MoveToY(-0.485f, HitObject.TimePreempt);
+
+            if ((HitObject as Beat).Feign)
+                this.Delay(HitObject.TimePreempt / 4).RotateTo(Rotation + 180, 200, Easing.OutPow10).FadeColour(Color4.White, 200, Easing.OutPow10);
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             if ((HitObject as Beat).Feign)
             {
                 Box.MoveToY(.2425f, HitObject.TimePreempt / 4).Then().MoveToY(-.2425f, HitObject.TimePreempt / 4).Then().MoveToY(-0.485f, HitObject.TimePreempt / 2);
-                this.Delay(HitObject.TimePreempt / 4).FadeColour(Color4.White, HitObject.TimePreempt / 4);
+                this.Delay(HitObject.TimePreempt / 4).FadeColour(Color4.White, HitObject.TimePreempt / 8);
             }
             else
                 Box.MoveToY(-0.485f, HitObject.TimePreempt);

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
@@ -55,9 +55,9 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                     },
                 }
             );
-            Colour = hitObject.Feign ? Color4.Aqua : Color4.White;
+            Colour = hitObject.Feign ? Color4.Red : Color4.White;
 
-            Rotation = hitObject.Angle + (hitObject.Feign ? 180 : 0);
+            Rotation = hitObject.Angle;
             Position = Vector2.Zero;
         }
 
@@ -75,10 +75,13 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             base.UpdateInitialTransforms();
 
             Box.FadeIn(HitObject.TimeFadeIn);
-            Box.MoveToY(-0.485f, HitObject.TimePreempt);
-
             if ((HitObject as Beat).Feign)
-                this.Delay(HitObject.TimePreempt / 4).RotateTo(Rotation + 180, 200, Easing.OutPow10).FadeColour(Color4.White, 200, Easing.OutPow10);
+            {
+                Box.MoveToY(.2425f, HitObject.TimePreempt / 4).Then().MoveToY(-.2425f, HitObject.TimePreempt / 4).Then().MoveToY(-0.485f, HitObject.TimePreempt / 2);
+                this.Delay(HitObject.TimePreempt / 4).FadeColour(Color4.White, HitObject.TimePreempt / 4);
+            }
+            else
+                Box.MoveToY(-0.485f, HitObject.TimePreempt);
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)


### PR DESCRIPTION
Just opening this here for visibility.

Feign notes appear to go in a specific direction (HitObject.Angle + 180), before rotating back to the correct direction halfway to the circle.

Currently can be set via a bool value, as I personally think that this is more a modifier than an actual note type, seeing as it could also be applied to other notes such as BigBeat.

Footage of the note in action (It replaces all notes simply for demonstration purposes): 
https://streamable.com/lbvj1e

TODO before this could even be considered ready, discussion preferably in the server:
- [x] Differentiate visual to not look exactly the same as regular beat (perhaps a colour change)
- [ ] Consider when this modifier should be used in the context of beatmaps converted from std