### PR TITLE
Enable detailed score statistics

### DIFF
--- a/osu.Game.Rulesets.Tau/TauRuleset.cs
+++ b/osu.Game.Rulesets.Tau/TauRuleset.cs
@@ -21,6 +21,8 @@ using osu.Game.Rulesets.Tau.Replays;
 using osu.Game.Rulesets.Tau.Scoring;
 using osu.Game.Rulesets.Tau.UI;
 using osu.Game.Rulesets.UI;
+using osu.Game.Scoring;
+using osu.Game.Screens.Ranking.Statistics;
 using osuTK;
 
 namespace osu.Game.Rulesets.Tau
@@ -102,6 +104,21 @@ namespace osu.Game.Rulesets.Tau
             new KeyBinding(InputKey.MouseLeft, TauAction.LeftButton),
             new KeyBinding(InputKey.MouseRight, TauAction.RightButton),
             new KeyBinding(InputKey.Space, TauAction.HardButton),
+        };
+
+        public override StatisticRow[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap) => new[]
+        {
+            new StatisticRow
+            {
+                Columns = new[]
+                {
+                    new StatisticItem("Timing Distribution", new HitEventTimingDistributionGraph(score.HitEvents)
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 250
+                    })
+                }
+            },
         };
 
         public override Drawable CreateIcon() => new Container


### PR DESCRIPTION
After countless nagging by @IKeepItNoodles, and the many times I said yes but never implemented this. I finally got my lazy arse to do this.

These show when clicking the score cards after a play.