### PR TITLE
Fix Cinema mod not working as expected

### DIFF
--- a/osu.Game.Rulesets.Tau/Mods/TauModCinema.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModCinema.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Tau.Objects;

--- a/osu.Game.Rulesets.Tau/Mods/TauModCinema.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModCinema.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Tau.Objects;
+using osu.Game.Rulesets.Tau.Replays;
+using osu.Game.Scoring;
+using osu.Game.Users;
+
+namespace osu.Game.Rulesets.Tau.Mods
+{
+    public class TauModCinema : ModCinema<TauHitObject>
+    {
+        public override Score CreateReplayScore(IBeatmap beatmap) => new Score
+        {
+            ScoreInfo = new ScoreInfo { User = new User { Username = "tau" } },
+            Replay = new TauAutoGenerator(beatmap).Generate()
+        };
+    }
+}

--- a/osu.Game.Rulesets.Tau/TauRuleset.cs
+++ b/osu.Game.Rulesets.Tau/TauRuleset.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Tau
                 case ModType.Automation:
                     return new Mod[]
                     {
-                        new MultiMod(new TauModAutoplay(), new ModCinema()),
+                        new MultiMod(new TauModAutoplay(), new TauModCinema()),
                         new TauModRelax(),
                     };
 


### PR DESCRIPTION
Fixes #116 

The default `ModCinema` doesn't hide the playfield, and only the abstract `ModCinema<T>` does that. This PR creates a `TauModCinema` for this purpose.