### PR TITLE
Fix combo-colouring

### DIFF
--- a/osu.Game.Rulesets.Tau/TauRuleset.cs
+++ b/osu.Game.Rulesets.Tau/TauRuleset.cs
@@ -130,5 +130,7 @@ namespace osu.Game.Rulesets.Tau
         public override IConvertibleReplayFrame CreateConvertibleReplayFrame() => new TauReplayFrame();
 
         public override HitObjectComposer CreateHitObjectComposer() => new TauHitObjectComposer(this);
+
+        public override IBeatmapProcessor CreateBeatmapProcessor(IBeatmap beatmap) => new BeatmapProcessor(beatmap);
     }
 }


### PR DESCRIPTION
Allows accent colouring to be correctly processed.

Fixes the following:
https://github.com/Altenhh/tau/blob/e84ec500baccef4be6497cfda0224d36676c2622/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauJudgement.cs#L41-L42