### PR TITLE
Adjust HitWindows

### DIFF
--- a/osu.Game.Rulesets.Tau/Scoring/TauHitWindows.cs
+++ b/osu.Game.Rulesets.Tau/Scoring/TauHitWindows.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Tau.Scoring
         {
             new DifficultyRange(HitResult.Great, 140, 100, 60),
             new DifficultyRange(HitResult.Ok, 200, 150, 100),
-            new DifficultyRange(HitResult.Miss, 400, 400, 400),
+            new DifficultyRange(HitResult.Miss, 200, 150, 100),
         };
     }
 }


### PR DESCRIPTION
The previous AABB validation window made gameplay way easier due to the simple fact that it doesn't allow for the `TimeOffset` to go too far in either direction, reducing the chances of getting an early miss.

This PR completely removes the potential to early miss, in favor of simply ignoring them. Late misses will still occur as usual, but with less leniency than before. (200ms tops instead of 400ms)