### PR TITLE
Implement notelock

### DIFF
--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             {
                 var result = HitObject.HitWindows.ResultFor(timeOffset);
 
-                if (result == HitResult.None)
+                if (result == HitResult.None || CheckHittable?.Invoke(this, Time.Current) == false)
                     return;
 
                 if (!validActionPressed)

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableHardBeat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableHardBeat.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
 
             var result = HitObject.HitWindows.ResultFor(timeOffset);
 
-            if (result == HitResult.None)
+            if (result == HitResult.None || CheckHittable?.Invoke(this, Time.Current) == false)
                 return;
 
             ApplyResult(r => r.Type = result);

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
@@ -27,5 +27,9 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
         protected TauAction? HitAction { get; set; }
 
         protected override double InitialLifetimeOffset => HitObject.TimePreempt;
+
+        public Func<DrawableHitObject, double, bool> CheckHittable;
+
+        public void MissForcefully() => ApplyResult(r => r.Type = r.Judgement.MinResult);
     }
 }

--- a/osu.Game.Rulesets.Tau/UI/OrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Tau/UI/OrderedHitPolicy.cs
@@ -1,0 +1,106 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Tau.Objects.Drawables;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Rulesets.Tau.UI
+{
+    /// <summary>
+    /// Ensures that <see cref="HitObject"/>s are hit in-order. Affectionately known as "note lock".
+    /// If a <see cref="HitObject"/> is hit out of order:
+    /// <list type="number">
+    /// <item><description>The hit is blocked if it occurred earlier than the previous <see cref="HitObject"/>'s start time.</description></item>
+    /// <item><description>The hit causes all previous <see cref="HitObject"/>s to missed otherwise.</description></item>
+    /// </list>
+    /// </summary>
+    public class OrderedHitPolicy
+    {
+        private readonly HitObjectContainer hitObjectContainer;
+
+        public OrderedHitPolicy(HitObjectContainer hitObjectContainer)
+        {
+            this.hitObjectContainer = hitObjectContainer;
+        }
+
+        /// <summary>
+        /// Determines whether a <see cref="DrawableHitObject"/> can be hit at a point in time.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="DrawableHitObject"/> to check.</param>
+        /// <param name="time">The time to check.</param>
+        /// <returns>Whether <paramref name="hitObject"/> can be hit at the given <paramref name="time"/>.</returns>
+        public bool IsHittable(DrawableHitObject hitObject, double time)
+        {
+            DrawableHitObject blockingObject = null;
+
+            foreach (var obj in enumerateHitObjectsUpTo(hitObject.HitObject.StartTime))
+            {
+                if (hitObjectCanBlockFutureHits(obj))
+                    blockingObject = obj;
+            }
+
+            // If there is no previous hitobject, allow the hit.
+            if (blockingObject == null)
+                return true;
+
+            // A hit is allowed if:
+            // 1. The last blocking hitobject has been judged.
+            // 2. The current time is after the last hitobject's start time.
+            // Hits at exactly the same time as the blocking hitobject are allowed for maps that contain simultaneous hitobjects (e.g. /b/372245).
+            return blockingObject.Judged || time >= blockingObject.HitObject.StartTime;
+        }
+
+        /// <summary>
+        /// Handles a <see cref="HitObject"/> being hit to potentially miss all earlier <see cref="HitObject"/>s.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> that was hit.</param>
+        public void HandleHit(DrawableHitObject hitObject)
+        {
+            // Hitobjects which themselves don't block future hitobjects don't cause misses (e.g. slider ticks, spinners).
+            if (!hitObjectCanBlockFutureHits(hitObject))
+                return;
+
+            if (!IsHittable(hitObject, hitObject.HitObject.StartTime + hitObject.Result.TimeOffset))
+                throw new InvalidOperationException($"A {hitObject} was hit before it became hittable!");
+
+            foreach (var obj in enumerateHitObjectsUpTo(hitObject.HitObject.StartTime))
+            {
+                if (obj.Judged)
+                    continue;
+
+                if (hitObjectCanBlockFutureHits(obj))
+                    ((DrawableTauHitObject)obj).MissForcefully();
+            }
+        }
+
+        /// <summary>
+        /// Whether a <see cref="HitObject"/> blocks hits on future <see cref="HitObject"/>s until its start time is reached.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> to test.</param>
+        private static bool hitObjectCanBlockFutureHits(DrawableHitObject hitObject)
+            => hitObject is DrawableBeat || hitObject is DrawableHardBeat;
+
+        private IEnumerable<DrawableHitObject> enumerateHitObjectsUpTo(double targetTime)
+        {
+            foreach (var obj in hitObjectContainer.AliveObjects)
+            {
+                if (obj.HitObject.StartTime >= targetTime)
+                    yield break;
+
+                yield return obj;
+
+                foreach (var nestedObj in obj.NestedHitObjects)
+                {
+                    if (nestedObj.HitObject.StartTime >= targetTime)
+                        break;
+
+                    yield return nestedObj;
+                }
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
@@ -144,6 +144,8 @@ namespace osu.Game.Rulesets.Tau.UI
 
         private void onNewResult(DrawableHitObject judgedObject, JudgementResult result)
         {
+            hitPolicy.HandleHit(judgedObject);
+
             if (!judgedObject.DisplayResult || !DisplayJudgements.Value)
                 return;
 

--- a/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
@@ -29,6 +29,7 @@ namespace osu.Game.Rulesets.Tau.UI
         private readonly TauCursor cursor;
         private readonly JudgementContainer<DrawableTauJudgement> judgementLayer;
         private readonly Container<KiaiHitExplosion> kiaiExplosionContainer;
+        private readonly OrderedHitPolicy hitPolicy;
 
         public static readonly Vector2 BASE_SIZE = new Vector2(768, 768);
 
@@ -97,6 +98,7 @@ namespace osu.Game.Rulesets.Tau.UI
                     Anchor = Anchor.Centre,
                 },
             });
+            hitPolicy = new OrderedHitPolicy(HitObjectContainer);
         }
 
         protected Bindable<float> PlayfieldDimLevel = new Bindable<float>(0.3f); // Change the default as you see fit
@@ -127,9 +129,9 @@ namespace osu.Game.Rulesets.Tau.UI
 
             switch (h)
             {
-                case DrawableTauHitObject _:
-                    var obj = (DrawableTauHitObject)h;
+                case DrawableTauHitObject obj:
                     obj.CheckValidation = CheckIfWeCanValidate;
+                    obj.CheckHittable = hitPolicy.IsHittable;
 
                     break;
             }


### PR DESCRIPTION
Copied straight from std (thanks osu!team!).

Mainly to avoid `HardBeat`s being receiving input while a previous `Beat` have yet to be judged, and vice-versa.

Works with the hit window changes in #134 