### PR TITLE
Add an extra key for HardButton. / Rename "Playfield" to "Ring" 

### DIFF
--- a/osu.Game.Rulesets.Tau/Mods/TauModRelax.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModRelax.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Rulesets.Tau.Mods
             {
                 if (hardhit)
                 {
-                    state.PressedActions.Add(TauAction.HardButton);
+                    state.PressedActions.Add(TauAction.HardButton1);
                 }
                 else
                 {

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableHardBeat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableHardBeat.cs
@@ -17,7 +17,8 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
     {
         protected override TauAction[] HitActions { get; set; } = new[]
         {
-            TauAction.HardButton
+            TauAction.HardButton1,
+            TauAction.HardButton2
         };
 
         public SkinnableDrawable Circle;

--- a/osu.Game.Rulesets.Tau/Replays/TauAutoGenerator.cs
+++ b/osu.Game.Rulesets.Tau/Replays/TauAutoGenerator.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Tau.Replays
                         break;
 
                     case HardBeat _:
-                        Replay.Frames.Add(new TauReplayFrame(h.StartTime, ((TauReplayFrame)Replay.Frames.Last()).Position, TauAction.HardButton));
+                        Replay.Frames.Add(new TauReplayFrame(h.StartTime, ((TauReplayFrame)Replay.Frames.Last()).Position, TauAction.HardButton1));
                         Replay.Frames.Add(new TauReplayFrame(h.StartTime + releaseDelay, ((TauReplayFrame)Replay.Frames.Last()).Position));
                         lastTime = h.GetEndTime() + releaseDelay;
 

--- a/osu.Game.Rulesets.Tau/Replays/TauReplayFrame.cs
+++ b/osu.Game.Rulesets.Tau/Replays/TauReplayFrame.cs
@@ -29,7 +29,8 @@ namespace osu.Game.Rulesets.Tau.Replays
 
             if (currentFrame.MouseLeft1) Actions.Add(TauAction.LeftButton);
             if (currentFrame.MouseRight1) Actions.Add(TauAction.RightButton);
-            if (currentFrame.MouseLeft2) Actions.Add(TauAction.HardButton);
+            if (currentFrame.MouseLeft2) Actions.Add(TauAction.HardButton1);
+            if (currentFrame.MouseRight2) Actions.Add(TauAction.HardButton2);
         }
 
         public LegacyReplayFrame ToLegacy(IBeatmap beatmap)
@@ -38,7 +39,8 @@ namespace osu.Game.Rulesets.Tau.Replays
 
             if (Actions.Contains(TauAction.LeftButton)) state |= ReplayButtonState.Left1;
             if (Actions.Contains(TauAction.RightButton)) state |= ReplayButtonState.Right1;
-            if (Actions.Contains(TauAction.HardButton)) state |= ReplayButtonState.Left2;
+            if (Actions.Contains(TauAction.HardButton1)) state |= ReplayButtonState.Left2;
+            if (Actions.Contains(TauAction.HardButton2)) state |= ReplayButtonState.Right2;
 
             return new LegacyReplayFrame(Time, Position.X, Position.Y, state);
         }

--- a/osu.Game.Rulesets.Tau/Skinning/Legacy/LegacyPlayfield.cs
+++ b/osu.Game.Rulesets.Tau/Skinning/Legacy/LegacyPlayfield.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Tau.Skinning.Legacy
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
                     FillMode = FillMode.Fit,
-                    Texture = skin.GetTexture("field-overlay")
+                    Texture = skin.GetTexture("ring-overlay")
                 }
             });
 

--- a/osu.Game.Rulesets.Tau/Skinning/Legacy/TauLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Tau/Skinning/Legacy/TauLegacySkinTransformer.cs
@@ -27,8 +27,8 @@ namespace osu.Game.Rulesets.Tau.Skinning.Legacy
                 case TauSkinComponents.Handle:
                     return Source.GetTexture("handle") != null ? new LegacyHandle() : null;
 
-                case TauSkinComponents.Playfield:
-                    return Source.GetTexture("field-overlay") != null ? new LegacyPlayfield() : null;
+                case TauSkinComponents.Ring:
+                    return Source.GetTexture("ring-overlay") != null ? new LegacyPlayfield() : null;
             }
 
             return null;

--- a/osu.Game.Rulesets.Tau/TauInputManager.cs
+++ b/osu.Game.Rulesets.Tau/TauInputManager.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Tau
             => new TauKeyBindingContainer(ruleset, variant, unique);
 
         public TauInputManager(RulesetInfo ruleset)
-            : base(ruleset, 0, SimultaneousBindingMode.All)
+            : base(ruleset, 0, SimultaneousBindingMode.Unique)
         {
         }
 
@@ -62,7 +62,10 @@ namespace osu.Game.Rulesets.Tau
         [Description("Right tick button")]
         RightButton,
 
-        [Description("Hard beat button")]
-        HardButton
+        [Description("Hard beat button 1")]
+        HardButton1,
+
+        [Description("Hard beat button 2")]
+        HardButton2,
     }
 }

--- a/osu.Game.Rulesets.Tau/TauInputManager.cs
+++ b/osu.Game.Rulesets.Tau/TauInputManager.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Tau
             => new TauKeyBindingContainer(ruleset, variant, unique);
 
         public TauInputManager(RulesetInfo ruleset)
-            : base(ruleset, 0, SimultaneousBindingMode.Unique)
+            : base(ruleset, 0, SimultaneousBindingMode.All)
         {
         }
 

--- a/osu.Game.Rulesets.Tau/TauRuleset.cs
+++ b/osu.Game.Rulesets.Tau/TauRuleset.cs
@@ -109,8 +109,8 @@ namespace osu.Game.Rulesets.Tau
             new KeyBinding(InputKey.X, TauAction.RightButton),
             new KeyBinding(InputKey.MouseLeft, TauAction.LeftButton),
             new KeyBinding(InputKey.MouseRight, TauAction.RightButton),
-            new KeyBinding(InputKey.Space, TauAction.HardButton),
-            new KeyBinding(InputKey.LShift, TauAction.HardButton),
+            new KeyBinding(InputKey.Space, TauAction.HardButton1),
+            new KeyBinding(InputKey.LShift, TauAction.HardButton2),
         };
 
         public override StatisticRow[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap) => new[]

--- a/osu.Game.Rulesets.Tau/TauRuleset.cs
+++ b/osu.Game.Rulesets.Tau/TauRuleset.cs
@@ -110,6 +110,7 @@ namespace osu.Game.Rulesets.Tau
             new KeyBinding(InputKey.MouseLeft, TauAction.LeftButton),
             new KeyBinding(InputKey.MouseRight, TauAction.RightButton),
             new KeyBinding(InputKey.Space, TauAction.HardButton),
+            new KeyBinding(InputKey.LShift, TauAction.HardButton),
         };
 
         public override StatisticRow[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap) => new[]

--- a/osu.Game.Rulesets.Tau/TauSkinComponents.cs
+++ b/osu.Game.Rulesets.Tau/TauSkinComponents.cs
@@ -3,7 +3,7 @@
     public enum TauSkinComponents
     {
         Beat,
-        Playfield,
+        Ring,
         HardBeat,
         Handle
     }

--- a/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Tau.UI
                     Origin = Anchor.Centre,
                 },
                 new VisualisationContainer(),
-                new SkinnableDrawable(new TauSkinComponent(TauSkinComponents.Playfield), _ => new PlayfieldPiece()),
+                new SkinnableDrawable(new TauSkinComponent(TauSkinComponents.Ring), _ => new PlayfieldPiece()),
                 HitObjectContainer,
                 cursor,
                 kiaiExplosionContainer = new Container<KiaiHitExplosion>


### PR DESCRIPTION
### Rename "Playfield" -> "Ring" for skinning.
"field-overlay" is now renamed to "ring-overlay" with this change, if you were working on a skin then please rename this file.

### Add an extra key for HardButton.

While I did not agree to add the extra key into the ruleset, people kept pushing me to add in the extra key.

The new default for this key is "Left Shift" and "Space", since those two seems to be the most prominent keys used in Tau.

---
don't know why these two commits were merged when i created this pull request...